### PR TITLE
Use `Option[int]` instead of `Option[string]` for `contentLength`

### DIFF
--- a/src/httpx.nim
+++ b/src/httpx.nim
@@ -184,7 +184,7 @@ proc send*(req: Request, code: HttpCode, body: string, contentLength: Option[int
   req.selector.updateHandle(req.client, {Event.Read, Event.Write})
 
 proc send*(req: Request, code: HttpCode, body: string, contentLength: Option[string], 
-           headers = "") {.inline, deprecated: "Use Option[int] contentLength".} =
+           headers = "") {.inline, deprecated: "Use Option[int] for contentLength parameter".} =
   req.send(code, body, some parseInt(contentLength.get($body.len)))
 
 template send*(req: Request, code: HttpCode, body: string, headers = "") =


### PR DESCRIPTION
Tested with this and it all seems to work properly
```nim
import options, asyncdispatch

import src/httpx

proc onRequest(req: Request): Future[void] =
  if req.httpMethod == some(HttpGet):
    case req.path.get()
    of "/":
      req.send("Hello World")
    of "/customLength":
      req.send(Http200, "Test", contentLength = some 10)
    else:
      req.send(Http404)

run(onRequest)
```

Has an overload for using `Option[string]` so old code isn't broken but is marked deprecated so people use the newer version 