### PR TITLE
Remove HTTP pipelining

### DIFF
--- a/tests/start_server.nim
+++ b/tests/start_server.nim
@@ -1,9 +1,11 @@
 import options, asyncdispatch, httpclient
-
+import strutils
 import ../src/httpx
 
-proc onRequest(req: Request) {.async.} =
-  if req.httpMethod == some(HttpGet):
+proc onRequest*(req: Request) {.async.} =
+  assert "form-data" notin req.path.get() # See issue13 test
+  case req.httpMethod.get()
+  of HttpGet:
     case req.path.get()
     of "/":
       req.send("Hi World!")
@@ -11,11 +13,14 @@ proc onRequest(req: Request) {.async.} =
       req.send("Hi there!")
     else:
       req.send(Http404)
-  elif req.httpMethod == some(HttpPost):
+  of HttpPost:
     case req.path.get()
     of "/":
       req.send("Successful POST! Data=" & $req.body.get().len)
+    of "/issues/13":
+      req.send(req.path.get())
     else:
       req.send(Http404)
-let settings = initSettings(numThreads = 1)
-run(onRequest, settings)
+  else: discard
+
+export httpx

--- a/tests/start_server.nim
+++ b/tests/start_server.nim
@@ -17,5 +17,5 @@ proc onRequest(req: Request) {.async.} =
       req.send("Successful POST! Data=" & $req.body.get().len)
     else:
       req.send(Http404)
-
-run(onRequest)
+let settings = initSettings(numThreads = 1)
+run(onRequest, settings)

--- a/tests/test_core/test_application.nim
+++ b/tests/test_core/test_application.nim
@@ -11,18 +11,14 @@ import strformat, os, osproc, terminal, strutils
 
 
 var process: Process
-when defined(windows):
-  if not fileExists("tests/start_server.exe"):
-    let code = execCmd("nim c --hints:off --verbosity=0 tests/start_server.nim")
-    if code != 0:
-      raise newException(IOError, "can't compile tests/start_server.nim")
-  process = startProcess(expandFileName("tests/start_server.exe"))
-else:
-  if not fileExists("tests/start_server"):
-    let code = execCmd("nim c --hints:off -d:usestd tests/start_server.nim")
-    if code != 0:
-      raise newException(IOError, "can't compile tests/start_server.nim")
-  process = startProcess(expandFileName("tests/start_server"))
+const binary ="tests/start_server" & ExeExt
+if not fileExists(binary):
+  echo "Compiling"
+  let code = execCmd("nim c --hints:off --verbosity=0 tests/start_server.nim")
+  echo code
+  if code != 0:
+    raise newException(IOError, "can't compile tests/start_server.nim")
+process = startProcess(expandFileName(binary))
 
 proc start() {.async.} =
   let address = "http://127.0.0.1:8080/content"

--- a/tests/test_core/test_application.nim
+++ b/tests/test_core/test_application.nim
@@ -7,62 +7,52 @@ discard """
   timeout:  60.0
 """
 import httpclient, asyncdispatch, nativesockets
-import strformat, os, osproc, terminal, strutils
+import strformat, os, osproc, terminal, strutils, base64
+import uri
 
+import ../start_server
 
-var process: Process
-const binary ="tests/start_server" & ExeExt
-if not fileExists(binary):
-  echo "Compiling"
-  let code = execCmd("nim c --hints:off --verbosity=0 tests/start_server.nim")
-  echo code
-  if code != 0:
-    raise newException(IOError, "can't compile tests/start_server.nim")
-process = startProcess(expandFileName(binary))
+proc expect(resp: Response, code: HttpCode, body: string) =
+  doAssert resp.code == code, $resp.code
+  doAssert resp.body == body, body
 
-proc start() {.async.} =
-  let address = "http://127.0.0.1:8080/content"
-  for i in 0 .. 20:
-    var client = newAsyncHttpClient()
-    styledEcho(fgBlue, "Getting ", address)
-    let fut = client.get(address)
-    yield fut or sleepAsync(4000)
-    if not fut.finished:
-      styledEcho(fgYellow, "Timed out")
-    elif not fut.failed:
-      styledEcho(fgGreen, "Server started!")
-      return
-    else: echo fut.error.msg
-    client.close()
+var serverThread: Thread[void]
 
-
-waitFor start()
-
+createThread(serverThread, proc () = run(onRequest))
 
 block:
   let
-    client = newAsyncHttpClient()
+    client = newHttpClient()
     address = "127.0.0.1"
     port = Port(8080)
-
+    root = parseUri(fmt"http://{address}:{port}")
+  sleep 100 # Give server some time to start
 
   # "can get /"
   block:
-    let
-      route = "/content"
-      response = waitFor client.get(fmt"http://{address}:{port}{route}")
-
-    doAssert response.code == Http200, $response.code
-    doAssert (waitFor response.body) == "Hi there!"
-
+    client.get(root / "content").expect(Http200, "Hi there!")
 
   # Simple POST
   block:
-    let
-      route = "/"
-      response = waitFor client.post(fmt"http://{address}:{port}{route}", body="hello")
-    
-    doAssert response.code == Http200
-    doAssert (waitFor response.body) == "Successful POST! Data=5"
+    client
+      .post(root, body="hello")
+      .expect(Http200, "Successful POST! Data=5")
+
+  # Can POST body have http method names in it
+  block issue13:
+    const body = """PUT-----------------------------232440040922467123362217795696
+Content-Disposition: form-data; name="request-type"
+
+PUT
+-----------------------------232440040922467123362217795696--"""
+    let headers = newHttpHeaders {
+      "Content-Type": "multipart/form-data; boundary=---------------------------180081423920632275152985699863",
+
+    }
+    client
+      .request(root / "issues/13", HttpPost, body = body, headers = headers)
+      .expect(Http200, "/issues/13")
+
 
   echo "done"
+  quit 0


### PR DESCRIPTION
Closes #13 
Removes HTTP pipelining which was causing a body to be parsed as a seperate request if it contained a method name inside it.

Pipelining seems to be disabled in most modern browsers anyways due to many issues
- https://en.wikipedia.org/wiki/HTTP_pipelining#Implementation_in_web_browsers
- https://stackoverflow.com/questions/30477476/why-is-pipelining-disabled-in-modern-browsers