### PR TITLE
Allow unknown `Content-Length`

### DIFF
--- a/tests/start_server.nim
+++ b/tests/start_server.nim
@@ -11,6 +11,8 @@ proc onRequest*(req: Request) {.async.} =
       req.send("Hi World!")
     of "/content":
       req.send("Hi there!")
+    of "/chunked":
+      req.send(Http200, "A\r\nHelloWorld\r\n0\r\n\r\n", none int, "Transfer-Encoding: chunked")
     else:
       req.send(Http404)
   of HttpPost:

--- a/tests/test_core/test_application.nim
+++ b/tests/test_core/test_application.nim
@@ -7,7 +7,7 @@ discard """
   timeout:  60.0
 """
 import httpclient, asyncdispatch, nativesockets
-import strformat, os, osproc, terminal, strutils, base64
+import strformat, os, httpcore
 import uri
 
 import ../start_server
@@ -30,7 +30,10 @@ block:
 
   # "can get /"
   block:
-    client.get(root / "content").expect(Http200, "Hi there!")
+    const expectedBody = "Hi there!"
+    let resp = client.get(root / "content")
+    resp.expect(Http200, expectedBody)
+    doAssert resp.headers["Content-Length"] == $expectedBody.len
 
   # Simple POST
   block:
@@ -53,6 +56,10 @@ PUT
       .request(root / "issues/13", HttpPost, body = body, headers = headers)
       .expect(Http200, "/issues/13")
 
+  block allowNoContentLength:
+    let resp = client.request(root / "chunked")
+    resp.expect(Http200, "HelloWorld")
+    doAssert not resp.headers.hasKey("Content-Length")
 
   echo "done"
   quit 0


### PR DESCRIPTION
Doesn't send `Content-Length` header if content length is `none(int)` which allows sending responses that need unknown content lengths such as [chunked transfer encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding#chunked_encoding) and [server sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events). 

Also adds the `closed` getter to check if a client is still connected which is needing for the responses above so that we can check if we should stop sending data or not