### PR TITLE
Expose more options, avoid descriptor exhaustion crashes, improve documentation

### DIFF
--- a/src/httpx.nim
+++ b/src/httpx.nim
@@ -389,7 +389,7 @@ proc processEvents(selector: Selector[Data],
     case data.fdKind
     of Server:
       if Event.Read in events[i].events:
-          tryAcceptClient()
+        tryAcceptClient()
       else:
         doAssert false, "Only Read events are expected for the server"
     of Dispatcher:

--- a/src/httpx.nim
+++ b/src/httpx.nim
@@ -113,6 +113,7 @@ const httpxServerName* {.strdefine.} =
     httpxDefaultServerName
   ## The server name sent in the Server header in responses.
   ## If not defined, the value of httpxDefaultServerName will be used.
+  ## If the value is empty, no Server header will be sent.
 
 const httpxClientBufDefaultSize* = 256
   ## The default size of the client read buffer.

--- a/src/httpx.nim
+++ b/src/httpx.nim
@@ -333,7 +333,13 @@ proc processEvents(selector: Selector[Data],
     case data.fdKind
     of Server:
       if Event.Read in events[i].events:
-          acceptClient()
+          try:
+            acceptClient()
+          except IOSelectorsException:
+            # Carry on without doing anything if the maximum number of descriptors is exhausted; hopefully there will be some available next tick
+            # termer 2023/03/20: There is no better way to check this error at the moment. The only way to differentiate descriptor exhaustion from other selector errors is based on its error message.
+            if getCurrentExceptionMsg() != "Maximum number of descriptors is exhausted!":
+              raise
       else:
         doAssert false, "Only Read events are expected for the server"
     of Dispatcher:

--- a/src/httpx.nim
+++ b/src/httpx.nim
@@ -271,9 +271,16 @@ template tryAcceptClient() =
 
   setBlocking(client, false)
 
-  # Only register the handle if the file descriptor count has not been reached
-  if likely(client.int < osMaxFdCount):
+  template regHandle() =
     selector.registerHandle(client, {Event.Read}, initData(Client, ip = address))
+
+  when usePosixVersion:
+    # Only register the handle if the file descriptor count has not been reached
+    if likely(client.int < osMaxFdCount):
+      regHandle()
+  else:
+    regHandle()
+    
 
 template closeClient(selector: Selector[Data],
                              fd: SocketHandle|int,

--- a/src/httpx.nim
+++ b/src/httpx.nim
@@ -175,9 +175,11 @@ proc send*(req: Request, code: HttpCode, body: string, contentLength: Option[int
     if contentLength.isSome:
       text &= "\c\LContent-Length: "
       text.addInt contentLength.unsafeGet()
-    text &= "\c\LServer: " & serverInfo
-    text &= "\c\LDate: "
-    text &= serverDate
+    
+    when serverInfo != "":
+      text &= "\c\LServer: " & serverInfo
+    
+    text &= "\c\LDate: " & serverDate
     text &= otherHeaders
     text &= "\c\L\c\L"
     text &= body
@@ -219,6 +221,7 @@ template acceptClient() =
         return
 
     raiseOSError(lastError)
+
   setBlocking(client, false)
   selector.registerHandle(client, {Event.Read},
                           initData(Client, ip = address))
@@ -330,7 +333,7 @@ proc processEvents(selector: Selector[Data],
     case data.fdKind
     of Server:
       if Event.Read in events[i].events:
-        acceptClient()
+          acceptClient()
       else:
         doAssert false, "Only Read events are expected for the server"
     of Dispatcher:

--- a/src/httpx.nim
+++ b/src/httpx.nim
@@ -16,26 +16,6 @@
 # limitations under the License.
 
 
-
-
-
-
-
-
-
-
-# TODO Set max headers size via constant that can be defined at compile time aas well
-
-
-
-
-
-
-
-
-
-
-
 import net, nativesockets, os, httpcore, asyncdispatch, strutils
 import options, logging, times, heapqueue, std/monotimes
 import std/sugar

--- a/src/httpx.nim
+++ b/src/httpx.nim
@@ -16,6 +16,26 @@
 # limitations under the License.
 
 
+
+
+
+
+
+
+
+
+# TODO Set max headers size via constant that can be defined at compile time aas well
+
+
+
+
+
+
+
+
+
+
+
 import net, nativesockets, os, httpcore, asyncdispatch, strutils
 import options, logging, times, heapqueue, std/monotimes
 import std/sugar
@@ -433,8 +453,7 @@ proc processEvents(selector: Selector[Data],
               if data.bytesSent != 0:
                 logging.warn("bytesSent isn't empty.")
 
-            #let waitingForBody = methodNeedsBody(data) and bodyInTransit(data)
-            let waitingForBody = false
+            let waitingForBody = methodNeedsBody(data) and bodyInTransit(data)
             if likely(not waitingForBody):
               # For pipelined requests, we need to reset this flag.
               data.headersFinished = true

--- a/src/httpx.nim
+++ b/src/httpx.nim
@@ -137,8 +137,10 @@ when httpxSendServerDate:
   # The date is updated every second from within the event loop.
   var serverDate {.threadvar.}: string
 
-let osMaxFdCount = selectors.maxDescriptors()
-  ## The maximum number of file descriptors allowed at one time by the OS
+
+when usePosixVersion:
+  let osMaxFdCount = selectors.maxDescriptors()
+    ## The maximum number of file descriptors allowed at one time by the OS
 
 proc doNothing(): Startup {.gcsafe.} =
   result = proc () {.closure, gcsafe.} =


### PR DESCRIPTION
I've exposed more options to the user via compile time consts that can be defined by the user, and I've also improved documentation in various areas that were bare.

I've also wrapped acceptClient in a try...except that ignores descriptor exhaustion errors, which fixes the ability for anyone to overload the server with connections and crash it.

Additionally, serverInfo has been renamed to httpxServerName (but the old constant still works), and defining it as empty will omit it from the HTTP response. Some users may not want to expose which HTTP server they're using to serve requests, and I think this would be a good thing to have as an option.